### PR TITLE
add requirements for ydn parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 .DS_Store
 yale_daily_news/*.json
-yale_daily_news/*.txt
 yale_daily_news/cropped_images
 yale_daily_news/numpy_arrays
 yale_daily_news/segmented_images

--- a/yale_daily_news/requirements.txt
+++ b/yale_daily_news/requirements.txt
@@ -1,0 +1,3 @@
+numpy==1.11.3
+scipy==0.18.1
+scikit-image==0.12.3


### PR DESCRIPTION
Ah, sorry about that! I was ignoring all .txt files in the ydn dir, including the requirements. This should settle that...

closes #6 