### PR TITLE
Tesseract headlines

### DIFF
--- a/yale_daily_news/requirements.txt
+++ b/yale_daily_news/requirements.txt
@@ -1,3 +1,5 @@
 numpy==1.11.3
 scipy==0.18.1
 scikit-image==0.12.3
+pytesseract==0.1.7
+PIL==1.1.7


### PR DESCRIPTION
First cut at storing ocr-recognized headlines as article metadata (re-using the existing `articles_to_titles.json` file)